### PR TITLE
Remove "Simulated Response" from the expectation

### DIFF
--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -84,7 +84,6 @@ feature "Reading in the browser", browser: true do
 
     expect(page).to have_text(<<-TEXT.strip_heredoc)
       Response
-      Simulated Response
 
       Status
       200


### PR DESCRIPTION
The words "Simulated Response" are not in the dummy app's documentation which is causing the spec failure on master.

This removes it from the integration_spec expectation