### PR TITLE
Add remote file opening via HTTP

### DIFF
--- a/lib/apitome/configuration.rb
+++ b/lib/apitome/configuration.rb
@@ -11,6 +11,8 @@ module Apitome
       :js_override,
       :readme,
       :single_page,
+      :remote_docs,
+      :remote_url,
       :url_formatter
     ]
 
@@ -24,6 +26,8 @@ module Apitome
     @@js_override  = nil
     @@readme       = "../api.md"
     @@single_page  = true
+    @@remote_docs  = false
+    @@remote_url   = nil
     @@url_formatter = -> (str) { str.gsub(/\.json$/, '').underscore.gsub(/[^0-9a-z]+/i, '-') }
 
     def self.root=(path)

--- a/lib/generators/apitome/install/templates/initializer.rb
+++ b/lib/generators/apitome/install/templates/initializer.rb
@@ -43,4 +43,15 @@ Apitome.setup do |config|
   # You can specify how urls are formatted using a Proc or other callable object.
   # Your proc will be called with a resource name or link, giving you the opportunity to modify it as necessary for in the documentation url.
   config.url_formatter = -> (str) { str.gsub(/\.json$/, '').underscore.gsub(/[^0-9a-z\:]+/i, '-') }
+
+  # You can setup the docs to be loaded from a remote URL if they are
+  # not available in the application environment. This defaujlts to
+  # false.
+  config.remote_docs = false
+
+  # If the remote_docs is set to true, this URL is used as the base for
+  # the doc location. This should be the root of the doc location, where
+  # the readme is located. It uses the doc_path setting to build the
+  # URLs for the API documentation. This defaults to nil.
+  config.remote_url = nil
 end


### PR DESCRIPTION
This adds support for loading the markdown and JSON from remote servers
by using `open-uri`. This means the docs can live outside of the
application server and not need to be generated or checked into the app.

The usecase for doing this is so that a Continuous Integration (CI)
server can generate the docs since it is already setup for the test
environment, which RAD requires. Then, after generation, it uploads the
RAD docs (JSON and markdown files) to a static file host, like AWS S3,
and then those docs get served to the application environments when
viewing the API docs.

This lets the docs be viewed in live application environments without
checking the docs into the app since they may change often.

-----

Let me know if this change is fitting for Apitome; if not, no worries. If I
need to add specs or adjust the Ruby style, totally let me know.

Thanks for building such a great doc viewer. :smile: