### PR TITLE
localize 'required'

### DIFF
--- a/app/views/apitome/docs/_params.html.erb
+++ b/app/views/apitome/docs/_params.html.erb
@@ -16,7 +16,7 @@
               <%= param['name'] %>
             <% end %>
             <% if param['required'] %>
-              <span class="label label-danger required">required</span>
+              <span class="label label-danger required"><%= t(:required) %></span>
             <% end %>
           </td>
           <td class="description"><%= param['description'] %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,13 +1,14 @@
 en:
   body: Body
   curl: cURL
+  endpoint: Endpoint
   headers: Headers
   parameters: Parameters
   query_parameters: Query Parameters
   readme: README
   request: Request
-  response: Response
+  required: required
   response_fields: Response Fields
+  response: Response
   route: Route
-  endpoint: Endpoint
   status: Status

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,13 +1,14 @@
 es:
   body: Cuerpo
   curl: cURL
+  endpoint: Punto de llegada
   headers: Encabezados
   parameters: Parametros
   query_parameters: Parámetros de la consulta
   readme: LEEME
   request: Solicitud
-  response: Respuesta
+  required: requerido
   response_fields: Campos de respuesta
+  response: Respuesta
   route: Ruta
-  endpoint: Punto de llegada
   status: Estado


### PR DESCRIPTION
The option for parameters to be <img width="65" alt="screen shot 2016-02-11 at 3 09 54 pm" src="https://cloud.githubusercontent.com/assets/1312687/12990747/9914a73a-d0d1-11e5-984d-12c791473dac.png"> isn't localized. This fixes it. 

I also included the Spanish locale <img width="71" alt="screen shot 2016-02-11 at 3 10 07 pm" src="https://cloud.githubusercontent.com/assets/1312687/12990748/99297b4c-d0d1-11e5-83fb-d8b9b1e6927a.png">

and sorted alphabetically the locales yml