### PR TITLE
don't splat paths if the app is single page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Apitome::Engine.routes.draw do
   root to: "docs#index"
   get "/simulate/*path", to: "docs#simulate"
-  get "/*path", to: "docs#show"
+  get "/*path", to: "docs#show" unless Apitome.configuration.single_page
 end


### PR DESCRIPTION
While using this, I noticed that I was getting some unwanted in my app when doing a single page doc.